### PR TITLE
Update install.adoc; recent Docker Engine on CentOS 7 may not have "docker" group

### DIFF
--- a/centos-ssh/install.adoc
+++ b/centos-ssh/install.adoc
@@ -42,6 +42,27 @@ add the account to "docker" group
 # usermod -a -G docker <you-account-name>
 --------
 
+[NOTE]
+===============================
+As of 1.12.6 on CentOS 7, the Docker group name is no longer "docker"
+but "dockerroot". If this is the case, run the following command
+instead.
+
+--------
+# usermod -a -G dockerroot <you-account-name>
+--------
+
+Also, dockerroot group may not have read/write access to the
+docker.sock file. If so, change the group of the file to dockerroot.
+
+--------
+# ls -l /var/run/docker.sock
+srw-rw----. 1 root root 0 May 29 01:48 /var/run/docker.sock
+# chown root:dockerroot /var/run/docker.sock
+--------
+
+===============================
+
 === Install Docker Compose on CentOS 7 or Fedora
 
 --------

--- a/centos-ssh/install.adoc
+++ b/centos-ssh/install.adoc
@@ -39,17 +39,17 @@ add the account to "docker" group
 (usermod below is effective after re-login tho the account).
 
 --------
-# usermod -a -G docker <you-account-name>
+# usermod -a -G docker <your-account-name>
 --------
 
 [NOTE]
 ===============================
-As of 1.12.6 on CentOS 7, the Docker group name is no longer "docker"
-but "dockerroot". If this is the case, run the following command
-instead.
+As of Docker Engine 1.12.6 on CentOS 7, the Docker group name is no
+longer "docker" but "dockerroot". If this is the case, run the
+following command instead.
 
 --------
-# usermod -a -G dockerroot <you-account-name>
+# usermod -a -G dockerroot <your-account-name>
 --------
 
 Also, dockerroot group may not have read/write access to the


### PR DESCRIPTION
Today, I set up Docker/Kubernetes environment on CentOS 7, and found Docker Engine did not create `docker` group. I am not sure this is a correct way to workaround but I used an existing `dockerroot` group and changed the owner of /var/run/docker.sock from `root:root` to `root:dockerroot`. I updated install.adoc with this workaround.

Docker Engine version: 1.12.6
